### PR TITLE
Changed git clone link to fix permission errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Our method also uses a small set of regularization images (200) to prevent overf
 ## Getting Started
 
 ```
-git clone git@github.com:adobe-research/custom-diffusion.git
+git clone https://github.com/adobe-research/custom-diffusion.git
 cd custom-diffusion
 git clone https://github.com/CompVis/stable-diffusion.git
 cd stable-diffusion


### PR DESCRIPTION
Fix problem where running `git clone git@github.com:adobe-research/custom-diffusion.git` on my computer results in permission error:
```Cloning into 'custom-diffusion'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.```